### PR TITLE
Work with users defined in LDAP posixGroups

### DIFF
--- a/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/user/LdapUserMapper.java
+++ b/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/user/LdapUserMapper.java
@@ -78,6 +78,8 @@ public class LdapUserMapper
             userConf.getString( UserConfigurationKeys.LDAP_MAPPER_USER_ATTRIBUTE_OBJECT_CLASS, userObjectClass );
         userFilter = userConf.getConcatenatedList( UserConfigurationKeys.LDAP_MAPPER_USER_ATTRIBUTE_FILTER, userFilter );
         maxResultCount = userConf.getInt( UserConfigurationKeys.LDAP_MAX_RESULT_COUNT, maxResultCount );
+
+        distinguishedNameAttribute = userConf.getString( UserConfigurationKeys.LDAP_DN_ATTRIBUTE, distinguishedNameAttribute );
     }
 
     public Attributes getCreationAttributes( User user, boolean encodePasswordIfChanged )

--- a/redback-configuration/src/main/java/org/apache/archiva/redback/configuration/UserConfigurationKeys.java
+++ b/redback-configuration/src/main/java/org/apache/archiva/redback/configuration/UserConfigurationKeys.java
@@ -74,6 +74,8 @@ public interface UserConfigurationKeys
 
     String LDAP_AUTHENTICATION_METHOD = "ldap.config.authentication.method";
 
+    String LDAP_DN_ATTRIBUTE = "ldap.config.dn";
+
     String LDAP_BASEDN = "ldap.config.base.dn";
 
     String LDAP_BINDDN = "ldap.config.bind.dn";


### PR DESCRIPTION
Add a configuration key `LDAP_DN_ATTRIBUTE`.

This patch enables authenticating with an LDAP instance configured to use _posixGroup_ LDAP groups with _memberUid_.

Configuring these parameters allows the use of such an LDAP-server:

```
ldap.config.dn: 'dn'
ldap.config.groups.member: 'memberUid'
ldap.config.groups.class: 'posixGroup'
```
