### PR TITLE
Fix for MRM-1873 which broke AD group assignments

### DIFF
--- a/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/role/DefaultLdapRoleMapper.java
+++ b/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/role/DefaultLdapRoleMapper.java
@@ -392,11 +392,9 @@ public class DefaultLdapRoleMapper
                 groupEntry = builder.toString();
             }
 
-            groupEntry = Rdn.escapeValue(groupEntry);
-
             String filter =
                 new StringBuilder().append( "(&" ).append( "(objectClass=" + getLdapGroupClass() + ")" ).append(
-                    "(" ).append( getLdapGroupMember() ).append( "=" ).append( groupEntry ).append( ")" ).append(
+                    "(" ).append( getLdapGroupMember() ).append( "=" ).append( Rdn.escapeValue(groupEntry) ).append( ")" ).append(
                     ")" ).toString();
 
             log.debug( "filter: {}", filter );


### PR DESCRIPTION
Escaping only needed in the LDAP filter string