### PR TITLE
Allowing filtering of LDAP groups

### DIFF
--- a/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/role/DefaultLdapRoleMapper.java
+++ b/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/role/DefaultLdapRoleMapper.java
@@ -92,6 +92,8 @@ public class DefaultLdapRoleMapper
 
     private String groupsDn;
 
+    private String groupFilter;
+
     private String baseDn;
 
     private String ldapGroupMember = "uniquemember";
@@ -120,6 +122,8 @@ public class DefaultLdapRoleMapper
             this.groupsDn = this.baseDn;
         }
 
+        this.groupFilter = userConf.getString( UserConfigurationKeys.LDAP_GROUPS_FILTER, this.groupFilter );
+
         this.useDefaultRoleName =
             userConf.getBoolean( UserConfigurationKeys.LDAP_GROUPS_USE_ROLENAME, this.useDefaultRoleName );
 
@@ -144,6 +148,11 @@ public class DefaultLdapRoleMapper
             searchControls.setSearchScope( SearchControls.SUBTREE_SCOPE );
 
             String filter = "objectClass=" + getLdapGroupClass();
+
+            if ( !StringUtils.isEmpty( this.groupFilter ) )
+            {
+                filter = "&(" + filter + ")(" + this.groupFilter + ")";
+            }
 
             namingEnumeration = context.search( getGroupsDn(), filter, searchControls );
 

--- a/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/role/DefaultLdapRoleMapper.java
+++ b/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/role/DefaultLdapRoleMapper.java
@@ -151,7 +151,7 @@ public class DefaultLdapRoleMapper
 
             if ( !StringUtils.isEmpty( this.groupFilter ) )
             {
-                filter = "&(" + filter + ")(" + this.groupFilter + ")";
+                filter = "(&(" + filter + ")(" + this.groupFilter + "))";
             }
 
             namingEnumeration = context.search( getGroupsDn(), filter, searchControls );

--- a/redback-configuration/src/main/java/org/apache/archiva/redback/configuration/UserConfigurationKeys.java
+++ b/redback-configuration/src/main/java/org/apache/archiva/redback/configuration/UserConfigurationKeys.java
@@ -84,6 +84,8 @@ public interface UserConfigurationKeys
 
     String LDAP_GROUPS_BASEDN = "ldap.config.groups.base.dn";
 
+    String LDAP_GROUPS_FILTER = "ldap.config.groups.filter";
+
     String LDAP_GROUPS_MEMBER = "ldap.config.groups.member";
 
     String LDAP_GROUPS_ROLE_START_KEY = "ldap.config.groups.role.";


### PR DESCRIPTION
Added a property to allow administrators to avoid loading all of the groups in their directory. We have hundreds of thousands and the query failed on our system previously.