### PR TITLE
Beautify case of default ldap group attribute

### DIFF
--- a/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/role/DefaultLdapRoleMapper.java
+++ b/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/role/DefaultLdapRoleMapper.java
@@ -96,7 +96,7 @@ public class DefaultLdapRoleMapper
 
     private String baseDn;
 
-    private String ldapGroupMember = "uniquemember";
+    private String ldapGroupMember = "uniqueMember";
 
     private boolean useDefaultRoleName = false;
 


### PR DESCRIPTION
More of a style issue, since attribute descriptions are case insensitive
according to RFC4512.

All tests pass.