### PR TITLE
Fix LDAP user mapping with apacheds-2.0.0-M23

### DIFF
--- a/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/user/LdapUserMapper.java
+++ b/redback-common/redback-common-ldap/src/main/java/org/apache/archiva/redback/common/ldap/user/LdapUserMapper.java
@@ -295,7 +295,7 @@ public class LdapUserMapper
 
     public String[] getReturningAttributes()
     {
-        return new String[]{ getUserIdAttribute(), getEmailAttribute(), getFullNameAttribute(), getPasswordAttribute(),
+        return new String[]{ "objectClass", getUserIdAttribute(), getEmailAttribute(), getFullNameAttribute(), getPasswordAttribute(),
             getDistinguishedNameAttribute() };
     }
 


### PR DESCRIPTION
I've been trying to set up Archiva to use the latest apacheds release, namely 2.0.0-M23, and found that archiva can only authenticate the user, but fails when trying to retrieve its attributes, which blocks users from logging in. I've described the problem in the commit message, but here is a verbose log excerpt for reference and discussion:

```
2016-09-07 01:30:31,031 [qtp652953800-27] INFO  org.apache.archiva.redback.authentication.ldap.LdapBindAuthenticator [] - user 'cipi' authenticated
2016-09-07 01:30:31,043 [qtp652953800-182] INFO  org.apache.archiva.redback.authentication.ldap.LdapBindAuthenticator [] - user 'cipi' authenticated
2016-09-07 01:30:31,211 [qtp652953800-28] ERROR org.apache.archiva.redback.users.ldap.LdapUserManager [] - Failed to find user: cipi
org.apache.archiva.redback.users.ldap.ctl.LdapControllerException: Failed to retrieve information for user: cipi
        at org.apache.archiva.redback.users.ldap.ctl.DefaultLdapController.getUser(DefaultLdapController.java:375) ~[redback-users-ldap-2.4.jar:2.4]
        at org.apache.archiva.redback.users.ldap.LdapUserManager.findUser(LdapUserManager.java:224) [redback-users-ldap-2.4.jar:2.4]
        at org.apache.archiva.redback.users.ldap.LdapUserManager.findUser(LdapUserManager.java:260) [redback-users-ldap-2.4.jar:2.4]
        at org.apache.archiva.web.security.ArchivaUserManagerAuthenticator.authenticate(ArchivaUserManagerAuthenticator.java:109) [archiva-web-common-2.2.1.jar:2.2.1]
        at org.apache.archiva.redback.authentication.DefaultAuthenticationManager.authenticate(DefaultAuthenticationManager.java:97) [redback-authentication-api-2.4.jar:2.4]
        at org.apache.archiva.redback.system.DefaultSecuritySystem.authenticate(DefaultSecuritySystem.java:102) [redback-system-2.4.jar:2.4]
        at org.apache.archiva.redback.integration.filter.authentication.HttpAuthenticator.authenticate(HttpAuthenticator.java:66) [redback-common-integrations-2.4.jar:2.4]
        at org.apache.archiva.redback.rest.services.DefaultLoginService.logIn(DefaultLoginService.java:153) [redback-rest-services-2.4.jar:2.4]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_101]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_101]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_101]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_101]
        at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:181) [cxf-core-3.0.3.jar:3.0.3]
        at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:97) [cxf-core-3.0.3.jar:3.0.3]
        at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:200) [cxf-rt-frontend-jaxrs-3.0.3.jar:3.0.3]
        at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:99) [cxf-rt-frontend-jaxrs-3.0.3.jar:3.0.3]
        at org.apache.cxf.interceptor.ServiceInvokerInterceptor$1.run(ServiceInvokerInterceptor.java:59) [cxf-core-3.0.3.jar:3.0.3]
        at org.apache.cxf.interceptor.ServiceInvokerInterceptor.handleMessage(ServiceInvokerInterceptor.java:96) [cxf-core-3.0.3.jar:3.0.3]
        at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307) [cxf-core-3.0.3.jar:3.0.3]
        at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121) [cxf-core-3.0.3.jar:3.0.3]
        at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:251) [cxf-rt-transports-http-3.0.3.jar:3.0.3]
        at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:223) [cxf-rt-transports-http-3.0.3.jar:3.0.3]
        at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:197) [cxf-rt-transports-http-3.0.3.jar:3.0.3]
        at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:149) [cxf-rt-transports-http-3.0.3.jar:3.0.3]
        at org.apache.cxf.transport.servlet.CXFNonSpringServlet.invoke(CXFNonSpringServlet.java:171) [cxf-rt-transports-http-3.0.3.jar:3.0.3]
        at org.apache.cxf.transport.servlet.AbstractHTTPServlet.handleRequest(AbstractHTTPServlet.java:290) [cxf-rt-transports-http-3.0.3.jar:3.0.3]
        at org.apache.cxf.transport.servlet.AbstractHTTPServlet.doPost(AbstractHTTPServlet.java:209) [cxf-rt-transports-http-3.0.3.jar:3.0.3]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:755) [javax.servlet-3.0.0.v201112011016.jar:?]
        at org.apache.cxf.transport.servlet.AbstractHTTPServlet.service(AbstractHTTPServlet.java:265) [cxf-rt-transports-http-3.0.3.jar:3.0.3]
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:684) [jetty-servlet-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1496) [jetty-servlet-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:85) [spring-web-4.2.1.RELEASE.jar:4.2.1.RELEASE]
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107) [spring-web-4.2.1.RELEASE.jar:4.2.1.RELEASE]
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1476) [jetty-servlet-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:499) [jetty-servlet-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:137) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:557) [jetty-security-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:231) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1086) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:428) [jetty-servlet-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:193) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1020) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:135) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:255) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:154) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.Server.handle(Server.java:370) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:494) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.AbstractHttpConnection.content(AbstractHttpConnection.java:982) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.content(AbstractHttpConnection.java:1043) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:865) [jetty-http-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:240) [jetty-http-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82) [jetty-server-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:667) [jetty-io-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:52) [jetty-io-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608) [jetty-util-8.1.14.v20131031.jar:8.1.14.v20131031]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543) [jetty-util-8.1.14.v20131031.jar:8.1.14.v20131031]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_101]
Caused by: javax.naming.NamingException: [LDAP: error code 80 - OTHER: failed for MessageType : SEARCH_REQUEST
Message ID : 2
    SearchRequest
        baseDn : 'ou=accounts,o=apifocal'
        filter : '(&(objectClass=inetorgperson:[10])(uid=cipi:[1]))'
        scope : whole subtree
        typesOnly : false
        Size Limit : no limit
        Time Limit : no limit
        Deref Aliases : deref Always
        attributes : 'uid', 'mail', 'displayName', 'userPassword', 'dn'
org.apache.directory.api.ldap.model.message.SearchRequestImpl@7a38a80    ManageDsaITImpl Control
        Type OID    : '2.16.840.1.113730.3.4.2'
        Criticality : 'false'
'
: ERR_296 objectClasses cannot be null]
        at com.sun.jndi.ldap.LdapCtx.mapErrorCode(LdapCtx.java:3179) ~[?:1.8.0_101]
        at com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:3081) ~[?:1.8.0_101]
        at com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:2888) ~[?:1.8.0_101]
        at com.sun.jndi.ldap.LdapCtx.searchAux(LdapCtx.java:1846) ~[?:1.8.0_101]
        at com.sun.jndi.ldap.LdapCtx.c_search(LdapCtx.java:1769) ~[?:1.8.0_101]
        at com.sun.jndi.toolkit.ctx.ComponentDirContext.p_search(ComponentDirContext.java:392) ~[?:1.8.0_101]
        at com.sun.jndi.toolkit.ctx.PartialCompositeDirContext.search(PartialCompositeDirContext.java:358) ~[?:1.8.0_101]
        at com.sun.jndi.toolkit.ctx.PartialCompositeDirContext.search(PartialCompositeDirContext.java:341) ~[?:1.8.0_101]
        at org.apache.archiva.redback.users.ldap.ctl.DefaultLdapController.searchUsers(DefaultLdapController.java:189) ~[redback-users-ldap-2.4.jar:2.4]
        at org.apache.archiva.redback.users.ldap.ctl.DefaultLdapController.getUser(DefaultLdapController.java:356) ~[redback-users-ldap-2.4.jar:2.4]
        ... 57 more
2016-09-07 01:30:31,212 [qtp652953800-28] WARN  org.apache.archiva.web.security.ArchivaUserManagerAuthenticator [] - Login for user cipi and userManager ldap failed, message: null
2016-09-07 01:30:31,216 [qtp652953800-28] WARN  org.apache.archiva.web.security.ArchivaUserManagerAuthenticator [] - Login for user cipi and userManager jdo failed. user not found.
2016-09-07 01:30:31,757 [qtp652953800-28] INFO  org.apache.archiva.redback.authentication.ldap.LdapBindAuthenticator [] - user 'cipi' authenticated
```

I wanted to add a unit test as well, but I've found that the `redback-users-ldap` module depends on apacheds-1.5.1. However, all existing tests pass.